### PR TITLE
Remove QToolTip styles from styles.css

### DIFF
--- a/themes/d49a15b7-3ea1-4fd4-9fd4-3e8279c888a2/styles.css
+++ b/themes/d49a15b7-3ea1-4fd4-9fd4-3e8279c888a2/styles.css
@@ -18,14 +18,6 @@
     --main: #10151d;
     --widget-background: #2983f0ba;
 }
-QToolTip {
-    padding: 6px;
-    color: #cdd6f4;
-    font-size: 12px;
-    background-color: #1e1e2e;
-    border: 0px solid #313244;
-    border-radius: 6px;
-}
 * {
     font-size: 12px;
     color: var(--text);
@@ -68,7 +60,6 @@ QToolTip {
 .disk-widget .widget-container,
 .apps-widget .widget-container,
 .home-widget .widget-container,
-/* .pomodoro-widget .widget-container, */
 .battery-widget .widget-container,
 .whkd-widget .widget-container,
 .traffic-widget .widget-container,


### PR DESCRIPTION
Removed QToolTip styles from the CSS file @amnweb, let me know if any more changes needed.