### PR TITLE
Fix: correct on_left duplicate to on_right for context_menu callback

### DIFF
--- a/themes/cd2adf60-84a1-436d-a0a9-95ac4c288928/config.yaml
+++ b/themes/cd2adf60-84a1-436d-a0a9-95ac4c288928/config.yaml
@@ -491,7 +491,7 @@ widgets:
       callbacks:
         on_left: "toggle_window"
         on_middle: "do_nothing"
-        on_left: "context_menu"
+        on_right: "context_menu"
   cpu:
     type: "yasb.cpu.CpuWidget"
     options:


### PR DESCRIPTION
This PR fixes the duplicate on_left callback in the taskbar widget by changing it to on_right for the context_menu action.